### PR TITLE
Updated README.md for Play2.5.x (about routesImport)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ libraryDependencies += "jp.t2v" %% "play2-pager-scalikejdbc" % "0.1.0" // option
     play.PlayImport.PlayKeys.routesImport += "jp.t2v.lab.play2.pager.Bindables._"
     ```
 
+    Please set the following configurations to build.sbt if your play's version is 2.5.x.
+
+    ```scala
+    TwirlKeys.templateImports += "jp.t2v.lab.play2.pager._"
+    play.sbt.routes.RoutesKeys.routesImport += "jp.t2v.lab.play2.pager.Pager"
+    play.sbt.routes.RoutesKeys.routesImport += "jp.t2v.lab.play2.pager.Bindables._"
+    ```
+
 1. define implicit `Sortable` value of your entities.
 
     * `default` is default sorting key and direction.


### PR DESCRIPTION
Hi gakuzzzz san!

In my environment that depends on Play 2.5.x, the procedure to set `routesImport` in README.md does not work. Because `play.PlayImport.PlayKeys.routesImport` can not be imported.

`play.sbt.routes.RoutesKeys.routesImport` imports succeeded.
For that reason I would like to update REAME.md.

Is it convenient for you?