### PR TITLE
Update for play2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: scala
 jdk:
-  - openjdk8
-  - oraclejdk8
+  - openjdk11
 scala:
-  - 2.12.7
-  - 2.11.12
+  - 2.13.10
+  - 2.12.17

--- a/README.md
+++ b/README.md
@@ -8,10 +8,19 @@ Pager support for Play2 application.
 
 ## Target
 
-Scala 2.11.x & 2.12.x
-Play 2.5.x & 2.6.x 
+Scala 2.11.x & 2.12.x & 2.13.x  
+Play 2.5.x & 2.6.x & 2.7.x
 
 ## Setup
+
+for Play 2.7.x
+
+```scala
+libraryDependencies += "jp.t2v" %% "play2-pager"             % "0.3.0"
+libraryDependencies += "jp.t2v" %% "play2-pager-scalikejdbc" % "0.3.0" // optional. it is useful when you use scalikejdbc.
+```
+
+for Play 2.5.x, 2.6.x
 
 ```scala
 libraryDependencies += "jp.t2v" %% "play2-pager"             % "0.2.0"
@@ -46,10 +55,10 @@ libraryDependencies += "jp.t2v" %% "play2-pager-scalikejdbc" % "0.2.0" // option
     package models.account
     
     import scalikejdbc._
-    import org.joda.time.{DateTime, LocalDate}
+    import java.time.{LocalDateTime, LocalDate}
     import jp.t2v.lab.play2.pager.{OrderType, Sortable}
     
-    case class Account(id: Int, name: Name, email: EMail, birthday: LocalDate, createdAt: DateTime)
+    case class Account(id: Int, name: Name, email: EMail, birthday: LocalDate, createdAt: LocalDateTime)
     
     object Account extends SQLSyntaxSupport[Account] {
     
@@ -111,7 +120,7 @@ libraryDependencies += "jp.t2v" %% "play2-pager-scalikejdbc" % "0.2.0" // option
 
 1. git clone
 1. cd play2-pager
-1. sbt "project sample" run
+1. sbt sample/run
 1. browse `http://localhost:9000/`
 1. Click `Apply this script now!`
 

--- a/build.sbt
+++ b/build.sbt
@@ -104,7 +104,7 @@ lazy val sample = (project in file("sample")).
       "org.scalikejdbc"          %% "scalikejdbc-play-initializer"        % "2.7.1-scalikejdbc-3.4",
       "org.scalikejdbc"          %% "scalikejdbc-syntax-support-macro"    % "3.4.+",
       guice,
-      "org.flywaydb"             %% "flyway-play"                         % "5.4.0",
+      "org.flywaydb"             %% "flyway-play"                         % "7.22.0",
     ),
     libraryDependencies ++= Seq(
       "com.fasterxml.jackson.module" %% "jackson-module-scala"            % "2.14.0",

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,8 @@
-scalaVersion := "2.12.7"
+scalaVersion := "2.13.10"
 
-val _version = "0.2.0"
+val _version = "0.3.0-SNAPSHOT"
 
-val _crossScalaVersions = Seq("2.12.7", "2.11.12")
+val _crossScalaVersions = Seq("2.13.10", "2.12.17")
 
 val _org = "jp.t2v"
 
@@ -47,7 +47,7 @@ lazy val _playVersion = play.core.PlayVersion.current
 lazy val root = (project in file(".")).
   aggregate(core, scalikejdbc, sample).
   settings(
-    aggregate in update := false,
+    update / aggregate  := false,
     crossScalaVersions  := _crossScalaVersions,
     publish             := { },
     publishArtifact     := false,
@@ -60,10 +60,9 @@ lazy val commonSettings = Seq(
   organization := _org,
   name := "play2-pager",
   version := _version,
-  scalaVersion := "2.12.7",
   crossScalaVersions := _crossScalaVersions,
   publishMavenStyle       := _publishMavenStyle,
-  publishArtifact in Test := _publishArtifactInTest,
+  Test / publishArtifact  := _publishArtifactInTest,
   pomIncludeRepository    := _pomIncludeRepository,
   publishTo               := _publishTo(_version),
   pomExtra                := _pomExtra
@@ -75,7 +74,7 @@ lazy val core = (project in file("core")).
     commonSettings,
     name := "play2-pager",
     libraryDependencies ++= Seq(
-      "com.typesafe.play" %% "play" % _playVersion  % "provided"
+      "com.typesafe.play" %% "play" % _playVersion  % Provided
     ),
     TwirlKeys.templateImports ++= Seq(
       "jp.t2v.lab.play2.pager._"
@@ -88,7 +87,7 @@ lazy val scalikejdbc = (project in file("scalikejdbc")).
     commonSettings,
     name := "play2-pager-scalikejdbc",
     libraryDependencies ++= Seq(
-      "org.scalikejdbc"  %% "scalikejdbc"  % "3.1.+"  % "provided"
+      "org.scalikejdbc"  %% "scalikejdbc"  % "3.4.+"  % Provided
     )
   )
 
@@ -99,17 +98,18 @@ lazy val sample = (project in file("sample")).
     commonSettings,
     name := "play2-pager-sample",
     libraryDependencies ++= Seq(
-      "com.h2database"           %  "h2"                                  % "1.4.+",
-      "ch.qos.logback"           %  "logback-classic"                     % "1.2.+",
-      "org.scalikejdbc"          %% "scalikejdbc"                         % "3.1.+",
-      "org.scalikejdbc"          %% "scalikejdbc-config"                  % "3.1.+",
-      "org.scalikejdbc"          %% "scalikejdbc-play-initializer"        % "2.6.0-scalikejdbc-3.1",
-      "org.scalikejdbc"          %% "scalikejdbc-syntax-support-macro"    % "3.1.+",
+      "com.h2database"           %  "h2"                                  % "2.1.+",
+      "org.scalikejdbc"          %% "scalikejdbc"                         % "3.4.+",
+      "org.scalikejdbc"          %% "scalikejdbc-config"                  % "3.4.+",
+      "org.scalikejdbc"          %% "scalikejdbc-play-initializer"        % "2.7.1-scalikejdbc-3.4",
+      "org.scalikejdbc"          %% "scalikejdbc-syntax-support-macro"    % "3.4.+",
       guice,
-      "org.flywaydb"             %% "flyway-play"                         % "4.0.0",
-      "net.sourceforge.htmlunit" %  "htmlunit"                            % "2.14"     % "test",
-      "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2" % "test"
+      "org.flywaydb"             %% "flyway-play"                         % "5.4.0",
     ),
+    libraryDependencies ++= Seq(
+      "com.fasterxml.jackson.module" %% "jackson-module-scala"            % "2.14.0",
+      "org.scalatestplus.play"       %% "scalatestplus-play"              % "4.0.0"
+    ).map(_ % Test),
     routesImport ++= Seq(
       "jp.t2v.lab.play2.pager.Pager",
       "jp.t2v.lab.play2.pager.Bindables._",
@@ -117,7 +117,8 @@ lazy val sample = (project in file("sample")).
     ),
     TwirlKeys.templateImports ++= Seq(
       "jp.t2v.lab.play2.pager._",
-      "models.account._"
+      "models.account._",
+      "java.time.format._"
     ),
     publish             := { },
     publishArtifact     := false,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,4 +1,4 @@
 #Activator-generated Properties
 #Tue Oct 07 18:47:36 JST 2014
 template.uuid=9d0f021d-ca8f-4a88-992f-f6468442419e
-sbt.version=0.13.16
+sbt.version=1.4.9

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.20")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.9")
 
 // web plugins
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.3")
+addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.4")

--- a/sample/app/controllers/Application.scala
+++ b/sample/app/controllers/Application.scala
@@ -6,7 +6,6 @@ import play.api.mvc._
 import models.ComponentRegistry
 import jp.t2v.lab.play2.pager.Pager
 import models.account.Account
-import play.filters.headers.SecurityHeadersFilter
 
 @Singleton
 class Application @Inject()(cc: ControllerComponents) extends AbstractController(cc) with ComponentRegistry {

--- a/sample/app/models/account/Account.scala
+++ b/sample/app/models/account/Account.scala
@@ -1,11 +1,11 @@
 package models.account
 
 import scalikejdbc._
-import org.joda.time.{DateTime, LocalDate}
+import java.time.{LocalDateTime, LocalDate}
 import jp.t2v.lab.play2.pager.{OrderType, Sortable}
 import scalikejdbc.WrappedResultSet
 
-case class Account(id: Int, name: Name, email: EMail, birthday: LocalDate, createdAt: DateTime)
+case class Account(id: Int, name: Name, email: EMail, birthday: LocalDate, createdAt: LocalDateTime)
 
 object Account extends SQLSyntaxSupport[Account] {
   override lazy val columns = autoColumns[Account]()

--- a/sample/app/views/index.scala.html
+++ b/sample/app/views/index.scala.html
@@ -25,8 +25,8 @@
               <th>@{account.id}</th>
               <td>@{account.name}</td>
               <td>@{account.email}</td>
-              <td>@{account.birthday.toString("yyyy/MM/dd")}</td>
-              <td>@{account.createdAt.toString("yyyy-MM-dd HH:mm:ss")}</td>
+              <td>@{account.birthday.format(DateTimeFormatter.ofPattern("yyyy/MM/dd"))}</td>
+              <td>@{account.createdAt.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))}</td>
           </tr>
         }
       </tbody>

--- a/sample/conf/application.conf
+++ b/sample/conf/application.conf
@@ -9,17 +9,11 @@
 # This must be changed for production, but we recommend not changing it in this file.
 #
 # See http://www.playframework.com/documentation/latest/ApplicationSecret for more details.
-application.secret="0_<WbUjEGNVJB3m@_phCHT@fr7p`EVY7nQlhvdl>5Bx`FfpMVDQYD^wgl4eLU5yD"
+play.http.secret.key="0_<WbUjEGNVJB3m@_phCHT@fr7p`EVY7nQlhvdl>5Bx`FfpMVDQYD^wgl4eLU5yD"
 
 # The application languages
 # ~~~~~
-application.langs="en"
-
-# Global object class
-# ~~~~~
-# Define the Global object class for this application.
-# Default to Global in the root package.
-# application.global=Global
+play.i18n.langs=["en"]
 
 # Router
 # ~~~~~
@@ -30,7 +24,7 @@ application.langs="en"
 # So for an application router like `my.application.Router`,
 # you may need to define a router file `conf/my.application.routes`.
 # Default to Routes in the root package (and conf/routes)
-# application.router=my.application.Routes
+# play.http.router=my.application.Routes
 
 # Database configuration
 # ~~~~~
@@ -39,7 +33,7 @@ application.langs="en"
 #
 db.default.driver=org.h2.Driver
 db.default.url="jdbc:h2:mem:play;DB_CLOSE_DELAY=-1"
-db.default.user=sa
+db.default.username=sa
 db.default.password=""
 
 db.default.poolInitialSize=10
@@ -50,22 +44,7 @@ db.default.poolMaxSize=10
 # You can disable evolutions if needed
 # evolutionplugin=disabled
 
-# Logger
-# ~~~~~
-# You can also configure logback (http://logback.qos.ch/),
-# by providing an application-logger.xml file in the conf directory.
-
-# Root logger:
-logger.root=ERROR
-
-# Logger used by the framework:
-logger.play=INFO
-
-# Logger provided to your application:
-logger.application=DEBUG
-
 play.modules.enabled += "scalikejdbc.PlayModule"
 play.modules.enabled += "org.flywaydb.play.PlayModule"
 
 play.filters.headers.contentSecurityPolicy=null
-


### PR DESCRIPTION
# 概要

- play 2.7.x に対応しました。

# 詳細

- 各種ライブラリをアップデートしました

| ライブラリ | 旧バージョン | 新バージョン | 備考 |
|---|---|---|---|
| scala | 2.11.12, 2.12.7 | 2.13.10, 2.12.17 | |
| sbt | 0.13.16 | 1.4.9 | |
| play | 2.6.20 | 2.7.9 | |
| h2 | 1.4.+ | 2.1.+ | sampleアプリ |
| scalikejdbc | 3.1.+ | 3.4.+ | |
| flyway-play | 4.0.0 | 7.22.0 | sampleアプリ |
| logback-classic | 1.2.+ | 削除 | sampleアプリ |
| jackson-module-scala | | 2.14.0 | sampleアプリ <br>ref https://github.com/FasterXML/jackson-module-scala/issues/513 |
| scalatestplus-play | 3.1.2 | 4.0.0 | sampleアプリ |

- (sampleアプリ)joda.timeではなくjava.timeを使用しました
- (sampleアプリ)古いconfキーを新しいものに変更しました
- travis ci で動かすjavaのバージョンを11に変更しました

# 備考

- sbt sample/run, および sbt sample/test を実行して、問題がないことを確認しています。
- 既存のtravisの設定があったので、そちらを変更しましたが、必要があれば同時にGitHub Actionにも変更したいと思います。
- こちらのマージ後に続けて、play 2.8向けのバージョンアップのプルリクエストも出したいと思います。